### PR TITLE
fix: configure happy-dom environment for browser-dependent tests

### DIFF
--- a/src/lib/apiClient.test.js
+++ b/src/lib/apiClient.test.js
@@ -8,6 +8,8 @@
  * - Chat streaming
  * - Error handling
  * - Token management
+ *
+ * @vitest-environment happy-dom
  */
 import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
 import { ApiClient, ApiError } from "./apiClient.ts";

--- a/src/lib/apiClient.test.ts
+++ b/src/lib/apiClient.test.ts
@@ -8,6 +8,8 @@
  * - Chat streaming
  * - Error handling
  * - Token management
+ *
+ * @vitest-environment happy-dom
  */
 
 import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";

--- a/src/services/ProfileService.test.js
+++ b/src/services/ProfileService.test.js
@@ -6,6 +6,8 @@
  * - Validation logic
  * - Error handling
  * - Memoization and caching
+ *
+ * @vitest-environment happy-dom
  */
 import { randomUUID } from "node:crypto";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";

--- a/src/services/ProfileService.test.ts
+++ b/src/services/ProfileService.test.ts
@@ -6,6 +6,8 @@
  * - Validation logic
  * - Error handling
  * - Memoization and caching
+ *
+ * @vitest-environment happy-dom
  */
 
 import { randomUUID } from "node:crypto";

--- a/src/services/SessionPersistenceService.browser.test.js
+++ b/src/services/SessionPersistenceService.browser.test.js
@@ -1,3 +1,5 @@
+// @vitest-environment happy-dom
+
 import { v4 as uuidv4 } from "uuid";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { SessionPersistenceService } from "./SessionPersistenceService.ts";


### PR DESCRIPTION
Add @vitest-environment happy-dom directive to test files that require
window and localStorage APIs. This resolves ReferenceError: window is
not defined failures by running these tests in a browser-like environment
instead of the default Node.js environment.

Fixed tests:
- SessionPersistenceService.browser.test.js (6 failures)
- ProfileService.test.ts (1 failure)
- ProfileService.test.js (1 failure)
- apiClient.test.ts (1 failure)
- apiClient.test.js (1 failure)

Closes #48

Generated with [Claude Code](https://claude.com/claude-code)